### PR TITLE
[compute_numeric_gradient] Use torch.flatten instead of view(-1).

### DIFF
--- a/coutils/eval.py
+++ b/coutils/eval.py
@@ -41,17 +41,17 @@ def compute_numeric_gradient(f, x, dy=None, h=1e-5):
   dx = torch.zeros_like(x)
 
   # Get flattened views of everything
-  x_flat = x.contiguous().view(-1)
-  y_flat = y.contiguous().view(-1)
-  dx_flat = dx.contiguous().view(-1)
-  dy_flat = dy.contiguous().view(-1)
+  x_flat = torch.flatten(x)
+  y_flat = torch.flatten(y)
+  dx_flat = torch.flatten(dx)
+  dy_flat = torch.flatten(dy)
   for i in range(dx_flat.shape[0]):
     # Compute numeric derivative dy/dx[i]
     orig = x_flat[i].item()
     x_flat[i] = orig + h
-    yph = f(x).clone().view(-1)
+    yph = torch.flatten(f(x).clone())
     x_flat[i] = orig - h
-    ymh = f(x).clone().view(-1)
+    ymh = torch.flatten(f(x).clone())
     x_flat[i] = orig
     dy_dxi = (yph - ymh) / (2.0 * h) 
 


### PR DESCRIPTION
I ran into technical issues when doing the convolutional network exercise from assignment 3 for the 2019 iteration of the class.
The issue was the same as https://github.com/deepvision-class/starter-code/issues/4 and stemmed from using `.view(-1)` to flatten the `f(x+h)` and `f(x-h)` tensors in the numerical gradient evaluation. Using `flatten` instead seems to fix the problem.

Unfortunately, I ran into another runtime error the "Batchnorm for deep convolutional networks" subsection. It seems to stem from the implementation of `FastConv`, but this might be more than I can chew right now.
